### PR TITLE
Split mypy report into its own command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
 ]
 [tool.hatch.envs.types.scripts]
 check = "mypy --install-types --non-interactive {args:src/drim2p/ tests/}"
+report = "check --html-report mypy-report/"
 
 # `test` environment
 [tool.hatch.envs.test]
@@ -72,7 +73,6 @@ pretty = true
 allow_redefinition = true
 warn_unreachable = true
 show_error_code_links = true
-html_report = "mypy-report/"
 [[tool.mypy.overrides]]
 module = ["h5py.*"]
 ignore_missing_imports = true


### PR DESCRIPTION
It was dumb to include the report in the config directly and not as a separate command.
The report takes a very long time to generate and makes `mypy` unusable with `live_mode = true` (through `pylsp`).

This keeps the option to generate it as a one-off but keeps `mypy` fast for normal use.