### PR TITLE
Fix various CLI bugs

### DIFF
--- a/src/drim2p/draw/roi.py
+++ b/src/drim2p/draw/roi.py
@@ -37,7 +37,9 @@ _logger = logging.getLogger(__name__)
     "-t",
     "--template",
     required=False,
-    type=click.Path(exists=True, file_okay=True, dir_okay=False),
+    type=click.Path(
+        exists=True, file_okay=True, dir_okay=False, path_type=pathlib.Path
+    ),
     default=None,
     help=(
         "Path to the HDF5 file to read default ROIs from. When provided, any ROIs "

--- a/src/drim2p/motion/correct.py
+++ b/src/drim2p/motion/correct.py
@@ -37,7 +37,9 @@ _logger = logging.getLogger(__name__)
     "-s",
     "--settings-path",
     required=False,
-    type=click.Path(exists=True, file_okay=True, dir_okay=False),
+    type=click.Path(
+        exists=True, file_okay=True, dir_okay=False, path_type=pathlib.Path
+    ),
     help="Path to the settings file to use.",
 )
 @click.option(
@@ -67,15 +69,6 @@ _logger = logging.getLogger(__name__)
         "Exclude filters to apply when searching for RAW files. "
         "This supports regular-expressions. Exclude filters are applied after all "
         "include filters."
-    ),
-)
-@click.option(
-    "--strict-filters",
-    required=False,
-    is_flag=True,
-    help=(
-        "Whether files not matching any include filter should be excluded, regardless "
-        "of exclude filters. This is ignored if no include filters are provided."
     ),
 )
 @click.option(


### PR DESCRIPTION
This completes the removal of the previously-not-properly-deleted `--strict-filters` option for `drim2p motion correct` and ensures `click.Path` options are properly converted to `pathlib.Path` when passed to the API.