### PR TITLE
Improve and centralise data output

### DIFF
--- a/docs/tutorials/dff-calculation.md
+++ b/docs/tutorials/dff-calculation.md
@@ -4,7 +4,7 @@ There are multiple ways to compute F₀, using a percentile, the mean, the media
 
 It is also possible to use a rolling window to continually update the F₀ value throughout the signal.
 
-This tutorial focuses on the using the defaults (5th percentile with no rolling window). For a more in-depth guide to customising the computation, see the [how-to guide]() and the [CLI reference](../reference/index.md#drim2p-deltaf).
+This tutorial focuses on using the default (5th percentile with no rolling window). For a more in-depth guide to customising the computation, see the [how-to guide]() and the [CLI reference](../reference/index.md#drim2p-deltaf).
 
 ## Calculating ΔF/F₀
 

--- a/docs/tutorials/motion-correction.md
+++ b/docs/tutorials/motion-correction.md
@@ -35,36 +35,10 @@ Finished motion correction in 0h 1m 0.00s.
 Saved motion correction to file.
 ```
 
-You will now see two new files in your directory:
+The motion corrected data will be saved automatically. However, you won't see a new file in your directory. That is one of the strengths of HDF5. You can store multiple bits of information inside the same file. Think of it as a ZIP archive, it's essentially a folder structure but all inside of one file.
 
-```shell
-tutorial/
-├── imaging_file.h5
-├── imaging_file.ini
-├── imaging_file.raw
-├── imaging_file.xml
-├── imaging_file_displacements.npz             (NEW)
-├── imaging_file_motion_correction_report.txt  (NEW)
-└── settings.toml.base
-```
-
-### Displacements
-
-The `imaging_file_displacements.npz` file is a [compressed NumPy file](https://numpy.org/devdocs/reference/routines.io.html#numpy-binary-files-npy-npz) containing information about the frame-to-frame displacements value used for the motion correction (under the 'displacements' key).
-
-
-### Report
-
-The `imaging_file_motion_correction_report.txt` file is a plain text file containing basic information about what settings were used for the motion correction as well as information about how long it took and which file was corrected.
-
-For our example imaging file, it looks like this:
-
-```text
-Chunk: imaging_file             (name of the file processed)
-Strategy: Fourier               (name of the strategy used)
-Displacement: [50, 50]          (maximum X and Y displacements allowed)
-Processing time: 0h 1m 0.00s    (time taken to motion correction)
-```
+!!! note
+    You don't need to keep the `settings.toml` file around your data. When you apply motion correction to a dataset, the settings used are added to the metadata of the motion corrected dataset.
 
 ## What's next?
 

--- a/docs/tutorials/roi-drawing.md
+++ b/docs/tutorials/roi-drawing.md
@@ -105,15 +105,13 @@ Image: Navigating grouped projections.
 
 ## Finalising the ROIs
 
-When you are happy with your ROIs and you are ready to move to the next step, simply close the GUI window.
+When you are happy with your ROIs and you are ready to move to the next step, simply close the GUI window and the ROIs will be saved.
 
-The ROIs will automatically be saved. However, you won't see a new file in your directory. That is one of the strengths of HDF5. You can store multiple bits of information inside the same file. Think of it as a ZIP archive, it's essentially a folder structure but all inside of one file. In fact, this is not the first time that we append to this file. At the end of motion correction, you might have noticed that we saved some extra files but not the motion corrected recording. That is because it was simply appended to the HDF5 file.
-
-If, for one reason or another, you have drawn a bunch of ROIs but do not want them to be saved, you should delete the 'ROIs' layer by selecting it (left click on its name) and clicking the bin icon above it and to the right. This will delete all the ROIs drawn during the current session since starting the GUI.
+If, for one reason or another, you have drawn a bunch of ROIs but do not want them to be saved, you should delete the 'ROIs' layer by selecting it (left click on its name) and clicking the bin icon above it and to the right. This will delete all the ROIs drawn during the current session since starting the GUI. Upon closing the GUI, any modification to the ROIs will be reverted.
 
 ## Editing existing ROIs
 
-Once ROIs have been saved to the HDF5 file, you can come back to it later on, run `drim2p draw roi .` and the GUI will reopen the file, with all its ROIs already drawn. Note that at this point, deleting the ROIs layer will not result in those pre-existing ROIs being deleted. If you wish to delete those, you will need to delete each ROI manually.
+Once ROIs have been saved to the HDF5 file, you can come back to it later on, run `drim2p draw roi .` and the GUI will reopen the file, with all its ROIs already drawn. Note that at this point, deleting the ROIs layer will not result in those pre-existing ROIs being deleted. If you wish to delete those, you will need to delete the ROIs without deleting the layer (this can be done by selecting all the ROIs with the select tool and pressing `delete` or `backspace` on your keyboard).
 
 ## What's next?
 

--- a/docs/tutorials/signal-extraction-and-decontamination.md
+++ b/docs/tutorials/signal-extraction-and-decontamination.md
@@ -22,7 +22,7 @@ Finished extracting signal.
 Once again, no extra file should be added to the directory, instead the extracted signals will be embedded into the HDF5 file.
 
 !!! note
-    The extracted signal arrays for each ROIs will have 5 signals. The first signal is the "true" signal after decontamination while the other four are the neuropil signals estimated by FISSA.
+    FISSA outputs signal arrays in the shape (5, timepoints), where the first index is the "true" signal and the next four are the neuropil ones. `drim2p` only saves the "true" signal under the normal preprocessing group. However, the neuropil signals are still saved in the QA group.
 
 ## What's next?
 

--- a/src/drim2p/convert/raw.py
+++ b/src/drim2p/convert/raw.py
@@ -314,7 +314,7 @@ def convert_raw(
         )
         with h5py.File(out_path, "w") as handle:
             dataset = handle.create_dataset(
-                "data",
+                io.ACQ_IMAGING_PATH,
                 data=array,
                 # Chunk per frame, same for writing but speeds up reading a lot
                 chunks=(1, *shape[1:]),
@@ -328,7 +328,7 @@ def convert_raw(
 
             if timestamps is not None:
                 handle.create_dataset(
-                    "timestamps",
+                    io.ACQ_TIMESTAMPS_PATH,
                     data=timestamps,
                     compression=compression,
                     compression_opts=compression_opts,

--- a/src/drim2p/deltaf/__init__.py
+++ b/src/drim2p/deltaf/__init__.py
@@ -211,18 +211,18 @@ def compute_dff(
         handle = h5py.File(path, "a", locking=False)
 
         # Retrieve signal group
-        signals_group = handle.get("extracted")
+        signals_group = handle.get(io.EXT_SIGNAL_LIST_PATH)
         if signals_group is None:
             _logger.error(
-                f"Could not find group 'extracted' inside of '{path}'. "
-                f"Available groups are: {list(handle)}. Skipping file."
+                f"Could not find group '{io.EXT_SIGNAL_LIST_PATH}' inside of '{path}'. "
+                f"Available groups at the root are: {list(handle)}. Skipping file."
             )
             continue
 
         # Check for existing ΔF/F₀
-        delta_f_group = handle.get("delta_f")
+        delta_f_group = handle.get(io.DEL_SIGNAL_PATH)
         if delta_f_group is None:
-            delta_f_group = handle.create_group("delta_f")
+            delta_f_group = handle.create_group(io.DEL_SIGNAL_PATH)
         elif delta_f_group is not None and not force:
             _logger.info(
                 f"ΔF/F₀ group already exists in '{path}' and 'force' was not set. "

--- a/src/drim2p/draw/roi.py
+++ b/src/drim2p/draw/roi.py
@@ -269,6 +269,7 @@ def draw_roi(
 
             _logger.debug("Saving ROIs.")
             roi_group = handle.create_group(io.ROI_LIST_PATH)
+            shape_types = []
             for index, (roi, shape_type) in enumerate(
                 zip(rois.data, rois.shape_type, strict=True)
             ):
@@ -285,9 +286,10 @@ def draw_roi(
                 # to the whole group later on. This makes it easier to inspect the HDF5
                 # file manually.
                 dataset.attrs["SHAPE_TYPE"] = shape_type
+                shape_types.append(shape_type)
 
             # Save ROI types
-            roi_group.attrs["SHAPE_TYPES"] = rois.shape_type
+            roi_group.attrs["SHAPE_TYPES"] = shape_types
 
 
 def _start_roi_gui(

--- a/src/drim2p/extract/signal.py
+++ b/src/drim2p/extract/signal.py
@@ -259,12 +259,23 @@ def _extract_signal_for_group(
         if handle.get(io.EXT_SIGNAL_LIST_PATH) is not None:
             _logger.debug("Deleting exisintg preprocessing.")
             del handle[io.EXT_SIGNAL_LIST_PATH]
+        if handle.get(io.EXT_NEUROPIL_PATH) is not None:
+            _logger.debug("Deleting exisintg QA.")
+            del handle[io.EXT_NEUROPIL_PATH]
 
         _logger.debug("Saving results.")
         extracted_group = handle.create_group(io.EXT_SIGNAL_LIST_PATH)
+        neuropil_group = handle.create_group(io.EXT_NEUROPIL_PATH)
         for roi_index in range(experiment.result.shape[0]):
-            extracted_group.create_dataset(
-                f"roi{roi_index}", data=experiment.result[roi_index, trial_index]
-            )
+            roi_results = experiment.result[roi_index, trial_index]
+
+            # At this point, we've got a 5xT array. Split it into two: one only contains
+            # the ROI signal, the other contains the neuropil contamination.
+            roi_signal = roi_results[0]
+            neuropil_contamination = roi_results[1:]
+
+            roi_name = f"roi{roi_index}"
+            extracted_group.create_dataset(roi_name, data=roi_signal)
+            neuropil_group.create_dataset(roi_name, data=neuropil_contamination)
 
     _logger.info("Finished extracting signal.")

--- a/src/drim2p/io/__init__.py
+++ b/src/drim2p/io/__init__.py
@@ -30,8 +30,10 @@ MOT_MEAN_PROJECTION_PATH = "/qa/motion_correction/mean_projection"
 ROI_LIST_PATH = "/preprocessing/rois"
 
 EXT_SIGNAL_LIST_PATH = "/preprocessing/extracted"
+EXT_NEUROPIL_PATH = "/qa/extracted/neuropil"
 
-DEL_SIGNAL_PATH = "/processing/deltaf"
+DEL_SIGNAL_LIST_PATH = "/processing/deltaf"
+DEL_NEUROPIL_PATH = "/qa/deltaf/neuropil"
 
 
 def collect_paths_from_extensions(

--- a/src/drim2p/motion/correct.py
+++ b/src/drim2p/motion/correct.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
+import contextlib
 import logging
 import pathlib
 import shutil
@@ -169,7 +170,7 @@ def _apply_motion_correction(
     # Keep own handle to check for motion correction dataset
     file = h5py.File(path, "a", locking=False)
 
-    if "imaging" in list(file) and not force:
+    if has_a_motion_corrected_dataset(file) and not force:
         _logger.info(
             f"Skipping '{path}' as it was already corrected and --force is not set."
         )
@@ -210,7 +211,9 @@ def _apply_motion_correction(
         shutil.rmtree(temp_sima_dataset_path)
 
     # Create a `Sequence` object from the HDF5 file that sima understands
-    sequences = [sima.Sequence.create("HDF5", path, key="data", dim_order="tyx")]
+    sequences = [
+        sima.Sequence.create("HDF5", path, key=io.ACQ_IMAGING_PATH, dim_order="tyx")
+    ]
     # Motion correct
     dataset, displacements = strategy.correct(sequences, temp_sima_dataset_path)
 
@@ -220,24 +223,12 @@ def _apply_motion_correction(
     time_string = f"{hours:.0f}h {minutes:.0f}m {duration:.2f}s"
     _logger.info(f"Finished motion correction in {time_string}.")
 
-    # TODO: Write motion correction parameters to file
-    report_string = f"""\
-Chunk: {path.stem}
-Strategy: {settings.strategy.name}
-Displacement: {list(settings.displacement)}
-Processing time: {time_string}\
-    """
-    with (
-        path.with_stem(path.stem + "_motion_correction_report")
-        .with_suffix(".txt")
-        .open("w") as handle
-    ):
-        handle.write(report_string)
-
     # Save motion corrected dataset and displacements
-    if "imaging" in list(file):  # Remote corrected dataset if it exists
-        _logger.debug(f"Removing existing 'imaging' dataset from '{path}'.")
-        del file["imaging"]
+    if has_a_motion_corrected_dataset(file):  # Remote corrected dataset if it exists
+        _logger.debug(
+            f"Removing existing motion corrected 'imaging' dataset from '{path}'."
+        )
+        del file[io.MOT_IMAGING_PATH]
 
     compression, compression_opts, shuffle = io.get_h5py_compression_parameters(
         compression, compression_opts
@@ -253,8 +244,8 @@ Processing time: {time_string}\
     # save 3/4 of the space by keeping it uint16.
     sequence = dataset.sequences[0]
     shape = sequence.shape
-    file_dataset = file.create_dataset(
-        "imaging",
+    imaging_dataset = file.create_dataset(
+        io.MOT_IMAGING_PATH,
         shape=shape[0:1] + shape[2:4],
         dtype=np.uint16,
         chunks=(1, *shape[2:4]),
@@ -264,13 +255,19 @@ Processing time: {time_string}\
     )
     for i, frame in enumerate(iter(sequence)):
         # No need to use `np.round` as the decimal part is seemingly always 0
-        file_dataset[i] = frame.squeeze().astype(np.uint16)
+        imaging_dataset[i] = frame.squeeze().astype(np.uint16)
 
     _logger.debug("Saving displacements.")
-    np.savez_compressed(
-        path.with_stem(path.stem + "_displacements").with_suffix(".npz"),
-        displacements=displacements,
-    )
+
+    displacements = displacements[0].squeeze()  # Go from 1xTx1x2 to Tx2
+    with contextlib.suppress(KeyError):  # Ensure it doesn't exist
+        del file[io.MOT_DISPLACEMENTS_PATH]
+    file.create_dataset(io.MOT_DISPLACEMENTS_PATH, data=displacements)
+
+    # Save some information about the settings used
+    imaging_dataset.attrs["STRATEGY"] = settings.strategy.name
+    imaging_dataset.attrs["MAX_DISPLACEMENT"] = settings.displacement
+    imaging_dataset.attrs["PROCESSING_TIME"] = time_string
 
     _logger.info("Saved motion correction to file.")
 
@@ -279,3 +276,15 @@ Processing time: {time_string}\
         temp_sima_dataset_path,
         onexc=lambda *_: _logger.debug("Failed to delete sima directory."),
     )
+
+
+def has_a_motion_corrected_dataset(handle: h5py.File) -> bool:
+    """Returns whether the given handle has an existing motion-corrected dataset.
+
+    Args:
+        handle (h5py.File): Handle to check.
+
+    Returns:
+        Whether such a dataset exists.
+    """
+    return handle.get(io.MOT_IMAGING_PATH) is not None


### PR DESCRIPTION
Closes #43.

This PR changes the way the HDF5 file is organised internally to have a much better (and therefore clearer) hierarchy.
Additionally, it merges the two files, `displacements.npz` and `motion_correction_report.txt` into the main HDF5 in the form of a dataset and attributes respectively.