### PR TITLE
Add flags for motion correction settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ test = [
   "pytest-cov",
 ]
 types = [
-  "mypy[install-types, faster-cache, reports]",
+  "mypy[install-types, faster-cache, reports]>=1.16",
 ]
 
 [tool.hatch.envs.default]
@@ -204,7 +204,8 @@ convention = "google"
 [tool.mypy]
 strict = true
 pretty = true
-#allow_redefinition_new = true  # Enable when mypy 1.16 drops
+allow_redefinition_new = true
+local_partial_types = true  # Necessary when allow_redefinition_new is enabled
 allow_redefinition = true
 warn_unreachable = true
 show_error_code_links = true

--- a/uv.lock
+++ b/uv.lock
@@ -453,7 +453,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocs-section-index" },
     { name = "mkdocstrings-python" },
-    { name = "mypy", extras = ["install-types", "faster-cache", "reports"] },
+    { name = "mypy", extras = ["install-types", "faster-cache", "reports"], specifier = ">=1.16" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -475,7 +475,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
-types = [{ name = "mypy", extras = ["install-types", "faster-cache", "reports"] }]
+types = [{ name = "mypy", extras = ["install-types", "faster-cache", "reports"], specifier = ">=1.16" }]
 
 [[package]]
 name = "duguidlab-motion-correction"


### PR DESCRIPTION
Currently, the user is forced to have a settings file handy every time they want to motion correct. This PR adds the current two settings to the CLI as flags.

Settings are taken first from the settings file if it is provided, then from the flags. Flags need to both be there without a settings file and are ignored with a settings file.

Should we make CLI settings the default and give them default values (same as the settings file)? This would make the CLI the same for every command (`drim2p <command> <subcommand> <path/to/data>`) but might become unwieldy if we need to add more settings in the future.